### PR TITLE
DiscordAPIError: Invalid Form Body

### DIFF
--- a/src/commands/config/features.ts
+++ b/src/commands/config/features.ts
@@ -80,7 +80,7 @@ export default class FeaturesCommand extends BushCommand {
 				customId: 'command_selectFeature',
 				disabled: disable, 
 				maxValues: 1,
-				minValues: 2,
+				minValues: 1,
 				options: guildFeatures.map((f) => ({
 					label: guildFeaturesObj[f].name,
 					value: f,


### PR DESCRIPTION
Fix error:
min_values must be equal to or less than 1. Error code: 50035: Invalid form body (returned for both application/json and multipart/form-data bodies), or invalid Content-Type provided